### PR TITLE
feat: job listing detail view, resizable panels, and issue tracking

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -1,5 +1,31 @@
-# TO DO fix issues and errors
+# ToDo — Known Issues & Improvements
 
-## Issues to fix
-### Issue one
-Whenever I switch my organizations it first shows me 404 not found until when I first go back and then again choose the organation that is when it works
+> A running list of bugs, enhancements, and technical debt to address.
+
+---
+
+## 🐛 Bugs
+
+### 1. Organization Switching Causes Intermittent 404
+
+- **Where:** Employer Dashboard — switching between organizations
+- **Steps to reproduce:**
+  1. Sign in and navigate to the Employer Dashboard.
+  2. Switch to a different organization from the sidebar.
+  3. The page immediately shows a **404 Not Found** error.
+  4. Navigate back to the home page and re-select the organization — it now loads correctly.
+- **Expected:** Switching organizations should seamlessly load the selected organization's dashboard without any 404 error.
+- **Suspected cause:** The route or middleware may not be re-evaluating the active organization context fast enough, leading to a stale or missing `orgId` during the transition.
+- **Priority:** High
+
+---
+
+## ✨ Enhancements
+
+_No enhancements logged yet._
+
+---
+
+## 🧹 Technical Debt
+
+_No technical debt items logged yet._

--- a/ToDo.md
+++ b/ToDo.md
@@ -1,0 +1,5 @@
+# TO DO fix issues and errors
+
+## Issues to fix
+### Issue one
+Whenever I switch my organizations it first shows me 404 not found until when I first go back and then again choose the organation that is when it works

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-hook-form": "^7.71.1",
+    "react-resizable-panels": "^4.6.5",
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "svix": "^1.84.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       react-hook-form:
         specifier: ^7.71.1
         version: 7.71.1(react@19.2.3)
+      react-resizable-panels:
+        specifier: ^4.6.5
+        version: 4.6.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -4582,6 +4585,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-resizable-panels@4.6.5:
+    resolution: {integrity: sha512-pmQP6qv9KmsesNMvWVNvVfVJAwYSOWWbAOAtrPR8Cre20+j1NWIlyft0btjtDQE+OepXmI6g3VPrCXQY0oD7+Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -10604,6 +10613,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.11)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.11
+
+  react-resizable-panels@4.6.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   react-style-singleton@2.2.3(@types/react@19.2.11)(react@19.2.3):
     dependencies:

--- a/src/app/(job-seeker)/@sidebar/job-listings/[jobListingId]/page.tsx
+++ b/src/app/(job-seeker)/@sidebar/job-listings/[jobListingId]/page.tsx
@@ -1,0 +1,6 @@
+import { JobBoardSidebar } from "@/app/(job-seeker)/_shared/JobBoardSidebar";
+
+
+export default function JobBoardSidebarPage() {
+  return <JobBoardSidebar />
+}

--- a/src/app/(job-seeker)/job-listings/[jobListingId]/_ClientSheet.tsx
+++ b/src/app/(job-seeker)/job-listings/[jobListingId]/_ClientSheet.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { Sheet } from "@/components/ui/sheet"
+import { useRouter, useSearchParams } from "next/navigation"
+import { ReactNode, useState } from "react"
+
+export function ClientSheet({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(true)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  return (
+    <Sheet
+      open={isOpen}
+      onOpenChange={open => {
+        if (open) return
+
+        setIsOpen(false)
+        router.push(`/?${searchParams.toString()}`)
+      }}
+      modal
+    >
+      {children}
+    </Sheet>
+  )
+}

--- a/src/app/(job-seeker)/job-listings/[jobListingId]/page.tsx
+++ b/src/app/(job-seeker)/job-listings/[jobListingId]/page.tsx
@@ -1,0 +1,209 @@
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@/components/ui/resizable";
+import { JobListingItems } from "../../_shared/JobListingItems";
+import { IsBreakpoint } from "@/components/IsBreakpoint";
+import { Suspense } from "react";
+import { LoadingSpinner } from "@/components/LoadingSpinner";
+import { SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { ClientSheet } from "./_ClientSheet";
+import { cacheTag } from "next/dist/server/use-cache/cache-tag";
+import { getJobListingIdTag } from "@/features/jobListings/db/cache/jobListings";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/drizzle/db";
+import { JobListingTable } from "@/drizzle/schema";
+import { getOrganizationIdTag } from "@/features/organizations/db/cache/organization";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+import { XIcon } from "lucide-react";
+import { convertSearchParamsToString } from "@/lib/convertSearchParamsToString";
+import { JobListingBadges } from "@/features/jobListings/components/JobListingBadges";
+import { MarkdownRenderer } from "@/components/markdown/MarkdownRenderer";
+import { getCurrentUser } from "@/services/clerk/lib/getCurrentAuth";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { SignUpButton } from "@/services/clerk/components/AuthButton";
+
+export default function JobListingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ jobListingId: string }>;
+  searchParams: Promise<Record<string, string | string[]>>;
+}) {
+  return (
+    <>
+      {/* @ts-expect-error: shadcn/ui types omit autoSaveId, but the underlying library supports it perfectly */}
+      <ResizablePanelGroup autoSaveId="job-board-panel" direction="horizontal">
+        {/* Removed 'id' and 'order' - it naturally becomes Panel 1 */}
+        <ResizablePanel defaultSize={60} minSize={30}>
+          <div className="p-4 h-screen overflow-y-auto">
+            <JobListingItems searchParams={searchParams} params={params} />
+          </div>
+        </ResizablePanel>
+
+        <IsBreakpoint
+          breakpoint="(min-width: 1024px)"
+          otherwise={
+            <ClientSheet>
+              <SheetContent hideCloseButton className="p-4">
+                <SheetHeader className="sr-only">
+                  <SheetTitle>Job Listing Details</SheetTitle>
+                </SheetHeader>
+                <Suspense fallback={<LoadingSpinner />}>
+                  <JobListingDetails
+                    searchParams={searchParams}
+                    params={params}
+                  />
+                </Suspense>
+              </SheetContent>
+            </ClientSheet>
+          }
+        >
+          {/* We wrap the Handle and the Right Panel in a React Fragment! */}
+          <>
+            <ResizableHandle withHandle className="mx-2" />
+
+            <ResizablePanel defaultSize={40} minSize={30}>
+              <div className="p-4 h-screen overflow-y-auto">
+                <Suspense fallback={<LoadingSpinner />}>
+                  <JobListingDetails
+                    params={params}
+                    searchParams={searchParams}
+                  />
+                </Suspense>
+              </div>
+            </ResizablePanel>
+          </>
+        </IsBreakpoint>
+      </ResizablePanelGroup>
+    </>
+  );
+}
+
+async function JobListingDetails({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ jobListingId: string }>;
+  searchParams: Promise<Record<string, string | string[]>>;
+}) {
+  const { jobListingId } = await params;
+  const resolvedSearchParams = await searchParams; // Safely await this at the top!
+
+  const jobListing = await getJobListing(jobListingId);
+  if (jobListing == null) return notFound();
+
+  const nameInitials = jobListing.organization.name
+    .split(" ")
+    .splice(0, 4)
+    .map((word) => word[0])
+    .join("");
+
+  return (
+    <div className="space-y-6 @container">
+      <div className="space-y-4">
+        <div className="flex gap-4 items-start">
+          <Avatar className="size-14 @max-md:hidden">
+            <AvatarImage
+              src={jobListing.organization.imageUrl ?? undefined}
+              alt={jobListing.organization.name}
+            />
+            <AvatarFallback className="uppercase bg-primary text-primary-foreground">
+              {nameInitials}
+            </AvatarFallback>
+          </Avatar>
+          <div className="flex flex-col gap-1">
+            <h1 className="text-2xl font-bold tracking-tight">
+              {jobListing.title}
+            </h1>
+            <div className="text-base text-muted-foreground">
+              {jobListing.organization.name}
+            </div>
+            {jobListing.postedAt != null && (
+              <div className="text-sm text-muted-foreground @min-lg:hidden">
+                {jobListing.postedAt.toLocaleDateString()}
+              </div>
+            )}
+          </div>
+          <div className="ml-auto flex items-center gap-4">
+            {jobListing.postedAt != null && (
+              <div className="text-sm text-muted-foreground @max-lg:hidden">
+                {jobListing.postedAt.toLocaleDateString()}
+              </div>
+            )}
+            <Button size="icon" variant="outline" asChild>
+              <Link
+                href={`/?${convertSearchParamsToString(resolvedSearchParams)}`}
+              >
+                <span className="sr-only">Close</span>
+                <XIcon />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mt-2">
+        <JobListingBadges jobListing={jobListing} />
+      </div>
+
+      <Suspense fallback={<Button disabled>Apply</Button>}>
+      <ApplyButton jobListingId={jobListing.id} />
+      </Suspense>
+
+
+      <MarkdownRenderer source={jobListing.description} />
+    </div>
+  );
+}
+
+
+async function ApplyButton({ jobListingId }: { jobListingId: string }) {
+  const { userId } = await getCurrentUser()
+  if (userId == null) {
+    return (
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button>Apply</Button>
+        </PopoverTrigger>
+        <PopoverContent className="flex flex-col gap-2">
+          You need to create an account before applying for a job.
+          <SignUpButton />
+        </PopoverContent>
+      </Popover>
+    )
+  }
+}
+
+
+
+async function getJobListing(id: string) {
+  "use cache";
+  cacheTag(getJobListingIdTag(id));
+
+  const listing = await db.query.JobListingTable.findFirst({
+    where: and(
+      eq(JobListingTable.id, id),
+      eq(JobListingTable.status, "published"),
+    ),
+    with: {
+      organization: {
+        columns: {
+          id: true,
+          name: true,
+          imageUrl: true,
+        },
+      },
+    },
+  });
+
+  if (listing != null) {
+    cacheTag(getOrganizationIdTag(listing.organization.id));
+  }
+
+  return listing;
+}

--- a/src/components/IsBreakpoint.tsx
+++ b/src/components/IsBreakpoint.tsx
@@ -1,0 +1,41 @@
+"use client"
+
+import { ReactNode, useEffect, useState } from "react"
+
+export function IsBreakpoint({
+  breakpoint,
+  children,
+  otherwise = null,
+}: {
+  breakpoint: string;
+  children: ReactNode;
+  otherwise?: ReactNode;
+}) {
+  const isBreakpointActive = useIsBreakpoint(breakpoint);
+  return isBreakpointActive ? children : otherwise;
+}
+
+function useIsBreakpoint(breakpoint: string) {
+  const [isBreakpoint, setIsBreakpoint] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = breakpoint.startsWith("(") ? breakpoint : `(${breakpoint})`;
+    const media = window.matchMedia(mediaQuery);
+    const controller = new AbortController();
+
+    // The update function
+    const onChange = () => setIsBreakpoint(media.matches);
+
+    // Call it immediately to set initial state (fixes the cascading render warning!)
+    onChange();
+
+    // Listen for window resizes
+    media.addEventListener("change", onChange, { signal: controller.signal });
+
+    return () => {
+      controller.abort();
+    };
+  }, [breakpoint]);
+
+  return isBreakpoint;
+}

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+import { Loader2Icon } from "lucide-react";
+import { ComponentProps } from "react";
+
+export function LoadingSpinner({
+  className,
+  ...props
+}: ComponentProps<typeof Loader2Icon>) {
+  return (
+    <div className="w-full h-full flex items-center justify-center">
+      <Loader2Icon
+        className={cn("animate-spin size-16", className)}
+        {...props}
+      />
+    </div>
+  )
+}

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { GripVerticalIcon } from "lucide-react"
+import * as ResizablePrimitive from "react-resizable-panels"
+
+import { cn } from "@/lib/utils"
+
+function ResizablePanelGroup({
+  className,
+  ...props
+}: ResizablePrimitive.GroupProps) {
+  return (
+    <ResizablePrimitive.Group
+      data-slot="resizable-panel-group"
+      className={cn(
+        "flex h-full w-full aria-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ResizablePanel({ ...props }: ResizablePrimitive.PanelProps) {
+  return <ResizablePrimitive.Panel data-slot="resizable-panel" {...props} />
+}
+
+function ResizableHandle({
+  withHandle,
+  className,
+  ...props
+}: ResizablePrimitive.SeparatorProps & {
+  withHandle?: boolean
+}) {
+  return (
+    <ResizablePrimitive.Separator
+      data-slot="resizable-handle"
+      className={cn(
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:after:-translate-y-1/2 [&[aria-orientation=horizontal]>div]:rotate-90",
+        className
+      )}
+      {...props}
+    >
+      {withHandle && (
+        <div className="bg-border z-10 flex h-4 w-3 items-center justify-center rounded-xs border">
+          <GripVerticalIcon className="size-2.5" />
+        </div>
+      )}
+    </ResizablePrimitive.Separator>
+  )
+}
+
+export { ResizableHandle, ResizablePanel, ResizablePanelGroup }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,31 +1,31 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { XIcon } from "lucide-react"
-import { Dialog as SheetPrimitive } from "radix-ui"
+import * as React from "react";
+import { XIcon } from "lucide-react";
+import { Dialog as SheetPrimitive } from "radix-ui";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
 function SheetTrigger({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
 function SheetClose({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Close>) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
 function SheetPortal({
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Portal>) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
 function SheetOverlay({
@@ -37,22 +37,24 @@ function SheetOverlay({
       data-slot="sheet-overlay"
       className={cn(
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function SheetContent({
   className,
   children,
+  hideCloseButton = false,
   side = "right",
-  showCloseButton = true,
+  // showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
-  side?: "top" | "right" | "bottom" | "left"
-  showCloseButton?: boolean
+  side?: "top" | "right" | "bottom" | "left";
+  hideCloseButton?: boolean;
+  // showCloseButton?: boolean
 }) {
   return (
     <SheetPortal>
@@ -69,12 +71,12 @@ function SheetContent({
             "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
           side === "bottom" &&
             "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
-          className
+          className,
         )}
         {...props}
       >
         {children}
-        {showCloseButton && (
+        {!hideCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
             <XIcon className="size-4" />
             <span className="sr-only">Close</span>
@@ -82,7 +84,7 @@ function SheetContent({
         )}
       </SheetPrimitive.Content>
     </SheetPortal>
-  )
+  );
 }
 
 function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -92,7 +94,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-1.5 p-4", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -102,7 +104,7 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("mt-auto flex flex-col gap-2 p-4", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetTitle({
@@ -115,7 +117,7 @@ function SheetTitle({
       className={cn("text-foreground font-semibold", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetDescription({
@@ -128,7 +130,7 @@ function SheetDescription({
       className={cn("text-muted-foreground text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -140,4 +142,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/src/features/jobListings/components/JobListingFilterForm.tsx
+++ b/src/features/jobListings/components/JobListingFilterForm.tsx
@@ -36,10 +36,22 @@ import {
 import { UGANDA_DISTRICTS } from "@/lib/constants/location";
 import { Button } from "@/components/ui/button";
 import { LoadingSwap } from "@/components/LoadingSwap";
-import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
 import { cn } from "@/lib/utils";
 import { Check, ChevronsUpDown } from "lucide-react";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useSidebar } from "@/components/ui/sidebar";
 
 const ANY_VALUE = "any";
 
@@ -59,6 +71,7 @@ export function JobListingFilterForm() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const pathname = usePathname();
+  const { setOpenMobile } = useSidebar();
 
   const form = useForm({
     resolver: zodResolver(jobListingFilterSchema),
@@ -94,6 +107,7 @@ export function JobListingFilterForm() {
     }
 
     router.push(`${pathname}?${newParams.toString()}`);
+    setOpenMobile(false);
   }
 
   return (
@@ -167,7 +181,7 @@ export function JobListingFilterForm() {
                       role="combobox"
                       className={cn(
                         "w-full justify-between",
-                        !field.value && "text-muted-foreground"
+                        !field.value && "text-muted-foreground",
                       )}
                     >
                       {field.value && field.value !== ANY_VALUE
@@ -177,7 +191,10 @@ export function JobListingFilterForm() {
                     </Button>
                   </FormControl>
                 </PopoverTrigger>
-                <PopoverContent className="w-[--radix-popover-trigger-width] p-0" align="start">
+                <PopoverContent
+                  className="w-[--radix-popover-trigger-width] p-0"
+                  align="start"
+                >
                   <Command>
                     <CommandInput placeholder="Search district..." />
                     <CommandList>
@@ -194,7 +211,7 @@ export function JobListingFilterForm() {
                               "mr-2 h-4 w-4",
                               field.value === ANY_VALUE || !field.value
                                 ? "opacity-100"
-                                : "opacity-0"
+                                : "opacity-0",
                             )}
                           />
                           Any
@@ -212,7 +229,7 @@ export function JobListingFilterForm() {
                                 "mr-2 h-4 w-4",
                                 districtName === field.value
                                   ? "opacity-100"
-                                  : "opacity-0"
+                                  : "opacity-0",
                               )}
                             />
                             {districtName}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,6 @@
 import { clerkMiddleware, createRouteMatcher } from '@clerk/nextjs/server'
 
-const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/", "/api(.*)"])
+const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/", "/api(.*)", "/job-listings(.*)"])
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {


### PR DESCRIPTION
## Summary

This pull request merges the latest `development` work into `main`, delivering a fully functional **job listing detail page** with responsive layout support, new reusable UI components, improved caching, and project documentation.

---

## Changes Included (14 commits)

### 🔧 Dependencies
- **react-resizable-panels (v4.6.5)**: Added as a dependency along with its lockfile entry to power the split-panel layout on the job detail page.

### 🔐 Authentication
- **Public route for `/job-listings`**: Added `/job-listings(.*)` to the Clerk public route matcher so individual job listing detail pages are accessible to unauthenticated users.

### 🧱 New UI Components
- **`ResizablePanelGroup`, `ResizablePanel`, `ResizableHandle`**: Accessible, drag-to-resize panel primitives built on `react-resizable-panels`.
- **`IsBreakpoint`**: Client-side component that conditionally renders children based on a CSS media query, enabling desktop vs. mobile layout switching.
- **`LoadingSpinner`**: Reusable centered spinner using Lucide's `Loader2Icon`.

### ♻️ Refactored Components
- **`Sheet` (`sheet.tsx`)**: Replaced `showCloseButton` with an inverted `hideCloseButton` prop for cleaner API usage. Applied consistent code formatting.
- **`JobListingFilterForm`**: Integrated `useSidebar().setOpenMobile(false)` to auto-close the mobile sidebar on filter submission. Reformatted imports and trailing commas.

### 🆕 Job Listing Detail Page
- **`/job-listings/[jobListingId]/page.tsx`**: Full detail page with:
  - 60/40 resizable split-panel layout on desktop (job list + detail side-by-side).
  - Bottom `Sheet` fallback on mobile via `IsBreakpoint`.
  - Organization avatar, job badges, posting date, markdown job description.
  - Auth-aware Apply button (sign-up prompt for unauthenticated users).
  - Per-listing and per-organization cache tags for granular invalidation.
- **`_ClientSheet.tsx`**: Client-side Sheet wrapper managing open/close state with search-param-preserving navigation on dismiss.
- **`@sidebar/job-listings/[jobListingId]/page.tsx`**: Parallel route ensuring the filter sidebar persists when viewing a job detail.

### 🗃️ Caching
- **`JobListingItems.tsx`**: Added per-organization cache tags (`getOrganizationIdTag`) so organization data changes (name, logo) properly invalidate cached job listing pages.

### 📝 Documentation
- **`ToDo.md`**: Added a structured issue tracker with categorized sections (Bugs, Enhancements, Technical Debt). Documents the organization-switching 404 bug with reproduction steps, expected behavior, and suspected cause.

---

## Testing Notes
- Verify the job detail page renders correctly at `/job-listings/<id>`.
- Confirm the resizable panels work on desktop and the sheet fallback works on mobile.
- Ensure the filter sidebar persists when navigating to a job detail.
- Verify unauthenticated users see the sign-up prompt when clicking Apply.